### PR TITLE
Fix readme so it acurately tells you what the function does

### DIFF
--- a/docs/help/Test-PartnerDomainAvailability.md
+++ b/docs/help/Test-PartnerDomainAvailability.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Test-PartnerDomainAvailability
 
 ## SYNOPSIS
-Tests if the specified domain name is available for creating a new tenant
+Tests if the specified domain name exists in CSP Domain list
 
 ## SYNTAX
 
@@ -18,7 +18,7 @@ Test-PartnerDomainAvailability [-Domain] <String> [<CommonParameters>]
 
 ## DESCRIPTION
 
-The Test-PartnerDomainAvailability cmdlet tests to see if the specified domain name is available for creating a new tenant.
+The Test-PartnerDomainAvailability cmdlet tests to see if the specified domain exists in your CSP Domain list. It does NOT validate whether this domain is available for creating a new tenant.
 
 ## EXAMPLES
 
@@ -27,7 +27,7 @@ The Test-PartnerDomainAvailability cmdlet tests to see if the specified domain n
 PS C:\> Test-PartnerDomainAvailability -Domain 'contoso.onmicrosoft.com'
 ```
 
-Tests if the domain contoso.onmicrosoft.com is available. Returns true if yes, false otherwise.
+Tests if the domain contoso.onmicrosoft.com exists in your CSP Domain list. Returns true if yes, false otherwise.
 
 ## PARAMETERS
 


### PR DESCRIPTION
# Description

Trying to clarify what this command actually does as in its current state it is very misleading.

It only checks via using API query to HEAD /v1/domains/<domain>.onmicrosoft.com HTTP/1.1 which results in checking if this domain is linked already to your CSP account.

It does NO validation whether this domain is already taken and if somebody where to use it as thus, he would be in all heaps of trouble.


Correct check is written here:

http://beyondthecloud.osb.group/2018/05/11/check-office365-tenant/

or here:

https://gist.github.com/jhochwald/9b70561e044a7a15040d8ba51b0faacf

or here:

https://stevenwatsonuk.wordpress.com/category/office-365/

Do NOT use this function if you want to validate if you can use specific domain or not.