### PR TITLE
fix typo next to billing address country

### DIFF
--- a/docs/help/New-PartnerCustomer.md
+++ b/docs/help/New-PartnerCustomer.md
@@ -27,7 +27,7 @@ Creates a new customer.
 
 ### Example 1
 ```powershell
-PS C:\> New-PartnerCustomer -BillingAddressLine1 '1 Microsoft Way' -BillingAddressCity 'Redmond' -BillingAddressCountry ;'US' -BillingAddressPostalCode '98052' -BillingAddressState 'WA' -ContactEmail 'jdoe@customer.com' -ContactFirstName 'Jane' -ContactLastName 'Doe' -Culture 'en-US' -Domain 'newcustomer.onmicrosoft.com' -Language 'en' -Name 'New Customer'
+PS C:\> New-PartnerCustomer -BillingAddressLine1 '1 Microsoft Way' -BillingAddressCity 'Redmond' -BillingAddressCountry 'US' -BillingAddressPostalCode '98052' -BillingAddressState 'WA' -ContactEmail 'jdoe@customer.com' -ContactFirstName 'Jane' -ContactLastName 'Doe' -Culture 'en-US' -Domain 'newcustomer.onmicrosoft.com' -Language 'en' -Name 'New Customer'
 ```
 
 Creates a new customer.


### PR DESCRIPTION
Fixing typo as there is ";" in front of the example one next to Billind AddressCountry and it would make it fail to run.