### PR TITLE
Add param length validation to domain availability checks

### DIFF
--- a/docs/help/New-PartnerCustomer.md
+++ b/docs/help/New-PartnerCustomer.md
@@ -214,8 +214,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Domain
+### -DomainDomain
 The customer's domain name, such as contoso.onmicrosoft.com.
+27 characters maximum domain prefix + 16 maximum characters suffix for '.onmicrosoft.com'
 
 ```yaml
 Type: String

--- a/docs/help/New-PartnerCustomer.md
+++ b/docs/help/New-PartnerCustomer.md
@@ -214,7 +214,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DomainDomain
+### -Domain
 The customer's domain name, such as contoso.onmicrosoft.com.
 27 characters maximum domain prefix + 16 maximum characters suffix for '.onmicrosoft.com'
 

--- a/docs/help/Test-PartnerDomainAvailability.md
+++ b/docs/help/Test-PartnerDomainAvailability.md
@@ -34,6 +34,7 @@ Tests if the domain contoso.onmicrosoft.com is available. Returns true if yes, f
 ### -Domain
 A string that identifies the domain to check, e.g.
 "contoso.onmicrosoft.com" .
+27 characters is maximum domain prefix + 16 maximum characters for the ".onmicrosoft.com" suffix
 
 ```yaml
 Type: String
@@ -59,5 +60,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.Boolean
 
 ## NOTES
+
+27 characters is maximum domain prefix + 16 maximum characters for the ".onmicrosoft.com" suffix
 
 ## RELATED LINKS

--- a/src/PowerShell/Commands/NewPartnerCustomer.cs
+++ b/src/PowerShell/Commands/NewPartnerCustomer.cs
@@ -107,8 +107,8 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
         /// <summary>
         /// Gets or sets the domain of the customer.
         /// </summary>
-        [Parameter(HelpMessage = "The customer's domain name, such as contoso.onmicrosoft.com.", Mandatory = true)]
-        [ValidateNotNullOrEmpty]
+        [Parameter(HelpMessage = "The customer's domain name, such as contoso.onmicrosoft.com. - 27 characters maximum + 16 suffix", Mandatory = true)]
+        [ValidateLength(17,43)]
         public string Domain { get; set; }
 
         /// <summary>

--- a/src/PowerShell/Commands/NewPartnerCustomer.cs
+++ b/src/PowerShell/Commands/NewPartnerCustomer.cs
@@ -107,8 +107,8 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
         /// <summary>
         /// Gets or sets the domain of the customer.
         /// </summary>
-        [Parameter(HelpMessage = "The customer's domain name, such as contoso.onmicrosoft.com. - 27 characters maximum + 16 suffix", Mandatory = true)]
-        [ValidateLength(17,43)]
+        [Parameter(HelpMessage = "The customer's domain name, such as contoso.onmicrosoft.com. - 27 characters maximum domain prefix + 16 maximum characters suffix for '.onmicrosoft.com'", Mandatory = true)]
+        [ValidateLength(17, 43)]
         public string Domain { get; set; }
 
         /// <summary>

--- a/src/PowerShell/Commands/TestPartnerDomainAvailability.cs
+++ b/src/PowerShell/Commands/TestPartnerDomainAvailability.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
         /// <summary>
         /// Test if the specified domain name is available.
         /// </summary>
-        [Parameter(HelpMessage = "A string that identifies the domain to check, e.g. \"contoso.onmicrosoft.com\" .", Mandatory = true, Position = 0)]
-        [ValidateNotNullOrEmpty]
+        [Parameter(HelpMessage = "A string that identifies the domain to check, e.g. \"contoso.onmicrosoft.com\" . - 27 characters maximum + 16 suffix", Mandatory = true, Position = 0)]
+        [ValidateLength(17,43)]
         public string Domain { get; set; }
 
         /// <summary>

--- a/src/PowerShell/Commands/TestPartnerDomainAvailability.cs
+++ b/src/PowerShell/Commands/TestPartnerDomainAvailability.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
         /// <summary>
         /// Test if the specified domain name is available.
         /// </summary>
-        [Parameter(HelpMessage = "A string that identifies the domain to check, e.g. \"contoso.onmicrosoft.com\" . - 27 characters maximum + 16 suffix", Mandatory = true, Position = 0)]
-        [ValidateLength(17,43)]
+        [Parameter(HelpMessage = "A string that identifies the domain to check, e.g. \"contoso.onmicrosoft.com\" . - 27 characters maximum domain prefix + 16 maximum characters suffix for '.onmicrosoft.com', Mandatory = true, Position = 0)]
+        [ValidateLength(17, 43)]
         public string Domain { get; set; }
 
         /// <summary>


### PR DESCRIPTION
# Description

Effectively the issue #7  was occurring because the comdlet validates address and domain availability but does not produce meaningful errors to warn you that it fails to validate those.

Probably the Test-PartnerDomainAvailability should be re-written a tad to give you a proper warning message but in the interim enforcing correct param length would be a good fix. 

The validate length addition to params will enforce you putting correct length for both functions/cmdlets.

The logic goes like this:

```powershell
$Count = "onboardingukcloud33csp12345"
$Count.Length

$Count1 = ".onmicrosoft.com"
$Count1.Length

$Count1.Length + $Count.Length

$DomainToTest = "onboardingukcloud33csp12345.onmicrosoft.com"
$DomainToTest.Length

Test-PartnerDomainAvailability -Domain $DomainToTest
```
So from here you have: 
$Count = 27
$Count1 = 16

Total = 43

Hence 16 is the ".omicrosoft.com" suffix that we need to take into account as that is embedded inside that function and 27 limit is enforced by CSP Portal check.

![image](https://user-images.githubusercontent.com/28607803/45127892-98a2e300-b172-11e8-9d9b-37e47667cc7e.png)

Which is why I proposed 17 minimum and 43 maximum as this gives us suffix + 1 character for domain and total of 43 maximum chars.

## Related issue
Helps diagnose and fix https://github.com/Microsoft/Partner-Center-PowerShell/issues/7
#7 