### PR TITLE
Added Default Value for Resource parameter

### DIFF
--- a/src/PowerShell/Commands/NewPartnerAccessToken.cs
+++ b/src/PowerShell/Commands/NewPartnerAccessToken.cs
@@ -73,9 +73,9 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
         /// <summary>
         /// Gets or sets the identifier of the target resource that is the recipient of the requested token.
         /// </summary>
-        [Parameter(HelpMessage = "The identifier of the target resource that is the recipient of the requested token.", Mandatory = true)]
+        [Parameter(HelpMessage = "The identifier of the target resource that is the recipient of the requested token.", Mandatory = false)]
         [ValidateNotNullOrEmpty]
-        public string Resource { get; set; }
+        public string Resource { get; set; } = "https://api.partnercenter.microsoft.com"
 
         /// <summary>
         /// Gets or sets a flag indicating that a service principal will be used to authenticate.


### PR DESCRIPTION
Added Default Value for Resource parameter/Class property

# Description

Added Default Value ("https://api.partnercenter.microsoft.com") for Resource parameter/Class property. This means that when running the command "New-PartnerAccessToken" the resource parameter no longer needs to be specified as most of the time it is only used against "https://api.partnercenter.microsoft.com" anyway.

## Related issue

Kindly link any related issues (e.g. Fixes #xyz).