### PR TITLE
Addressed parameter set cannot be resolved issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $appId = '<Web-AAD-AppId-for-PartnerCenter>'
 $appSecret = '<Web-AAD-AppSecret>' | ConvertTo-SecureString -AsPlainText -Force
 $credential = New-Object System.Management.Automation.PSCredential $appId $appSecret
 
-Connect-PartnerCenter -Credential $credential -ServicePrincipal -TenantId '<TenantId>'
+Connect-PartnerCenter -Credential $credential -TenantId '<TenantId>'
 ```
 
 #### User Credentials
@@ -67,7 +67,7 @@ $appId = '<AAD-AppId-for-PartnerCenter>'
 $appSecret = '<AAD-AppSecret>' | ConvertTo-SecureString -AsPlainText -Force
 $PSCredential = New-Object System.Management.Automation.PSCredential $appId, $appSecret
 
-$token = New-PartnerAccessToken -Credential $PSCredential -ServicePrincipal -TenantId '<TenantId>'
+$token = New-PartnerAccessToken -Credential $PSCredential -TenantId '<TenantId>'
 
 Connect-PartnerCenter -AccessToken $token.AccessToken -ApplicationId '<AAD-AppId-for-PartnerCenter>' -TenantId '<TenantId>'
 ```

--- a/docs/help/Connect-PartnerCenter.md
+++ b/docs/help/Connect-PartnerCenter.md
@@ -58,7 +58,7 @@ Connect to Partner Center using the specified application identifier during auth
 
 ```powershell
 PS C:\> $credential = Get-Credential
-PS C:\> Connect-PartnerCenter -Credential $credential -ServicePrincipal -TenantId '<AppId>'
+PS C:\> Connect-PartnerCenter -Credential $credential -TenantId '<AppId>'
 ```
 
 Connects to Partner Center using app only authentication. When prompted for credential specify the application identifier for the username and the application secret for the password.

--- a/docs/help/Connect-PartnerCenter.md
+++ b/docs/help/Connect-PartnerCenter.md
@@ -14,20 +14,21 @@ Connects to Partner Center with an authenticated account for use with cmdlet req
 
 ## SYNTAX
 
-### UserCredential (Default)
+### User (Default)
 ```
-Connect-PartnerCenter -ApplicationId <String> [-Environment <EnvironmentName>] [<CommonParameters>]
+Connect-PartnerCenter -ApplicationId <String> [-Environment <EnvironmentName>] [-TenantId <String>]
+ [<CommonParameters>]
 ```
 
 ### AccessToken
 ```
-Connect-PartnerCenter -AccessToken <String> -ApplicationId <String> [-Environment <EnvironmentName>]
- -TenantId <String> [<CommonParameters>]
+Connect-PartnerCenter -AccessToken <String> -ApplicationId <String> [-Credential <PSCredential>]
+ [-Environment <EnvironmentName>] [-TenantId <String>] [<CommonParameters>]
 ```
 
 ### ServicePrincipal
 ```
-Connect-PartnerCenter -Credential <PSCredential> [-Environment <EnvironmentName>] [-ServicePrincipal]
+Connect-PartnerCenter [-ApplicationId <String>] -Credential <PSCredential> [-Environment <EnvironmentName>]
  -TenantId <String> [<CommonParameters>]
 ```
 
@@ -84,7 +85,7 @@ The application identifier used to access the Partner Center API.
 
 ```yaml
 Type: String
-Parameter Sets: UserCredential, AccessToken
+Parameter Sets: User, AccessToken
 Aliases:
 
 Required: True
@@ -94,8 +95,32 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+```yaml
+Type: String
+Parameter Sets: ServicePrincipal
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Credential
 User credentials to be used when connecting to Partner Center.
+
+```yaml
+Type: PSCredential
+Parameter Sets: AccessToken
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ```yaml
 Type: PSCredential
@@ -115,25 +140,10 @@ Name of the environment containing the account to log into
 ```yaml
 Type: EnvironmentName
 Parameter Sets: (All)
-Aliases: EnvironmentName
+Aliases:
 Accepted values: GlobalCloud, ChinaCloud, GermanCloud, USGovernment
 
 Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ServicePrincipal
-A flag indiicating that a service principal will be used to authenticate.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: ServicePrincipal
-Aliases:
-
-Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -145,7 +155,19 @@ The Azure AD domain or tenant identifier.
 
 ```yaml
 Type: String
-Parameter Sets: AccessToken, ServicePrincipal
+Parameter Sets: User, AccessToken
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: String
+Parameter Sets: ServicePrincipal
 Aliases:
 
 Required: True

--- a/docs/help/Get-PartnerCustomerOrder.md
+++ b/docs/help/Get-PartnerCustomerOrder.md
@@ -14,6 +14,11 @@ Gets either a specific order or a list of order for the specified customer.
 
 ## SYNTAX
 
+### ByBillingCycle
+```
+Get-PartnerCustomerOrder -BillingCycle <BillingCycleType> -CustomerId <String> [<CommonParameters>]
+```
+
 ### ByCustomerId
 ```
 Get-PartnerCustomerOrder -CustomerId <String> [<CommonParameters>]
@@ -22,11 +27,6 @@ Get-PartnerCustomerOrder -CustomerId <String> [<CommonParameters>]
 ### ByOrderId
 ```
 Get-PartnerCustomerOrder -CustomerId <String> -OrderId <String> [<CommonParameters>]
-```
-
-### ByBillingCycle
-```
-Get-PartnerCustomerOrder -CustomerId <String> -BillingCycle <BillingCycleType> [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docs/help/New-PartnerAccessToken.md
+++ b/docs/help/New-PartnerAccessToken.md
@@ -37,7 +37,7 @@ The New-PartnerAccessToken command generates a new access token that can be used
 PS C:\> $appId = '<AAD-AppId>'
 PS C:\> $appSecret = '<AAD-AppSecret>' | ConvertTo-SecureString -AsPlainText -Force
 PS C:\> $credential = New-Object System.Management.Automation.PSCredential $appId $appSecret
-PS C:\> New-PartnerAccessToken -Credential $credential -ServicePrincipal -TenantId '<TenantId>'
+PS C:\> New-PartnerAccessToken -Credential $credential -TenantId '<TenantId>'
 ```
 
 Generates a new access token using a service principal for authentication.

--- a/src/PartnerCenter.TestFramework/PartnerCenter.TestFramework.csproj
+++ b/src/PartnerCenter.TestFramework/PartnerCenter.TestFramework.csproj
@@ -12,6 +12,8 @@
     <PackageProjectUrl>https://github.com/Microsoft/Partner-Center-PowerShell</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Microsoft/Partner-Center-PowerShell.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <Version>1.5.1902.2</Version>
+    <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PartnerCenter/PartnerCenter.csproj
+++ b/src/PartnerCenter/PartnerCenter.csproj
@@ -9,7 +9,7 @@
     <Copyright>Copyright ©  2019</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Product>Microsoft Partner Center</Product>
-    <Version>1.5.1902.1</Version>
+    <Version>1.5.1902.2</Version>
     <PackageLicenseUrl>https://github.com/Microsoft/Partner-Center-PowerShell/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Microsoft/Partner-Center-PowerShell</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Microsoft/Partner-Center-PowerShell.git</RepositoryUrl>

--- a/src/PowerShell/Commands/ConnectPartnerCenter.cs
+++ b/src/PowerShell/Commands/ConnectPartnerCenter.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
         /// <summary>
         /// Gets or sets the service principal credential.
         /// </summary>
+        [Parameter(HelpMessage = "Credentials that represents the service principal.", Mandatory = false, ParameterSetName = AccessTokenParameterSet)]
         [Parameter(HelpMessage = "Credentials that represents the service principal.", Mandatory = true, ParameterSetName = ServicePrincipalParameterSet)]
         [ValidateNotNull]
         public PSCredential Credential { get; set; }

--- a/src/PowerShell/PowerShell.csproj
+++ b/src/PowerShell/PowerShell.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/Microsoft/Partner-Center-PowerShell.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <Version>1.5.1902.1</Version>
+    <Version>1.5.1902.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

Through this pull request the following changes are being made 

1. Corrected an issue where the parameter set was not resolved when using the `-Credential` parameter
2. Updated the documentation to reflect the changes to the `Connect-PartnerCenter` command
3. Updated the version has been updated to 1.5.1902.2
 
## Related issue

#67 #68 