### PR TITLE
New breaking changes feature

### DIFF
--- a/src/PartnerCenter/Network/PartnerServiceClient.cs
+++ b/src/PartnerCenter/Network/PartnerServiceClient.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Store.PartnerCenter.Network
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Net;
     using System.Net.Http;
@@ -48,6 +49,11 @@ namespace Microsoft.Store.PartnerCenter.Network
         /// The name of the correlation identifier header.
         /// </summary>
         private const string CorrelationIdHeaderName = "MS-CorrelationId";
+
+        /// <summary>
+        /// The name of the enforce MFA header.
+        /// </summary>
+        private const string EnforceMfaHeader = "MS-Enforce-MFA";
 
         /// <summary>
         /// The name of the locale header.
@@ -824,6 +830,11 @@ namespace Microsoft.Store.PartnerCenter.Network
             if (!string.IsNullOrEmpty(PartnerService.Instance.ApplicationName))
             {
                 request.Headers.Add(ApplicationNameHeader, PartnerService.Instance.ApplicationName);
+            }
+
+            if (PartnerService.Instance.EnforceMfa)
+            {
+                request.Headers.Add(EnforceMfaHeader, true.ToString(CultureInfo.InvariantCulture));
             }
 
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaType));

--- a/src/PartnerCenter/PartnerCenter.csproj
+++ b/src/PartnerCenter/PartnerCenter.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
     <Reference Include="System.Web" />
   </ItemGroup>
 

--- a/src/PartnerCenter/PartnerService.cs
+++ b/src/PartnerCenter/PartnerService.cs
@@ -111,6 +111,18 @@ namespace Microsoft.Store.PartnerCenter
         /// access all the Partner Center APIs.
         /// </summary>
         /// <param name="credentials">The partner credentials. Use the <see cref="IPartnerCredentials" /> class to obtain these.</param>
+        /// <param name="httpClient">The HTTP client to be used.</param>
+        /// <returns>A configured partner operations object.</returns>
+        public IPartner CreatePartnerOperations(IPartnerCredentials credentials, HttpClient httpClient)
+        {
+            return Factory.Build(credentials, httpClient);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IPartner" /> instance and configures it using the provided partner credentials. The partner instance can be used to
+        /// access all the Partner Center APIs.
+        /// </summary>
+        /// <param name="credentials">The partner credentials. Use the <see cref="IPartnerCredentials" /> class to obtain these.</param>
         /// <param name="handlers">List of handlers from top to bottom (outer handler is the first in the list).</param>
         /// <returns>A configured partner operations object.</returns>
         public IPartner CreatePartnerOperations(IPartnerCredentials credentials, params DelegatingHandler[] handlers)

--- a/src/PartnerCenter/PartnerService.cs
+++ b/src/PartnerCenter/PartnerService.cs
@@ -73,6 +73,15 @@ namespace Microsoft.Store.PartnerCenter
         internal dynamic Configuration { get; private set; }
 
         /// <summary>
+        /// Gets or sets a flag indicating whether or not multi-factor authentication should be enforced.
+        /// </summary>
+        /// <remarks>
+        /// This flag is only configurable while the requirement for multi-factor authentication is not required.
+        /// Once the Partner Center API requires multi-factor authentication this flag will be removed.
+        /// </remarks>
+        public bool EnforceMfa { get; set; }
+
+        /// <summary>
         /// Gets the partner factory used to create partner objects.
         /// </summary>
         internal IPartnerFactory Factory { get; set; }

--- a/src/PowerShell/Attributes/BreakingChangeAttribute.cs
+++ b/src/PowerShell/Attributes/BreakingChangeAttribute.cs
@@ -1,0 +1,48 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BreakingChangeAttribute.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.Store.PartnerCenter.PowerShell
+{
+    /// <summary>
+    /// Attribute that describes a breaking change.
+    /// </summary>
+    public sealed class BreakingChangeAttribute : BreakingChangeBaseAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the breaking change.</param>
+        public BreakingChangeAttribute(string message) : base(message)
+        {
+            message.AssertNotEmpty(nameof(message));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the breaking change.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        public BreakingChangeAttribute(string message, string deprecateByVersion) : base(message, deprecateByVersion)
+        {
+            message.AssertNotEmpty(nameof(message));
+            deprecateByVersion.AssertNotEmpty(nameof(deprecateByVersion));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the breaking change.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        /// <param name="changeInEfectByDate">The data when the change will be required.</param>
+        public BreakingChangeAttribute(string message, string deprecateByVersion, string changeInEfectByDate)
+            : base(message, deprecateByVersion, changeInEfectByDate)
+        {
+            message.AssertNotEmpty(nameof(message));
+            deprecateByVersion.AssertNotEmpty(nameof(deprecateByVersion));
+            changeInEfectByDate.AssertNotEmpty(nameof(changeInEfectByDate));
+        }
+    }
+}

--- a/src/PowerShell/Attributes/BreakingChangeBaseAttribute.cs
+++ b/src/PowerShell/Attributes/BreakingChangeBaseAttribute.cs
@@ -1,0 +1,196 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BreakingChangeBaseAttribute.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.Store.PartnerCenter.PowerShell
+{
+    using System;
+    using System.Globalization;
+    using System.Linq;
+    using System.Management.Automation;
+    using Properties;
+
+    /// <summary>
+    /// The base class used by all breaking change attributes.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+    public abstract class BreakingChangeBaseAttribute : Attribute
+    {
+        /// <summary>
+        /// The message that describes the breaking change.
+        /// </summary>
+        private readonly string message;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakingChangeBaseAttribute" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the breaking change.</param>
+        public BreakingChangeBaseAttribute(string message)
+        {
+            message.AssertNotEmpty(nameof(message));
+
+            this.message = message;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakingChangeBaseAttribute" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the breaking change.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        public BreakingChangeBaseAttribute(string message, string deprecateByVersion)
+        {
+            message.AssertNotEmpty(nameof(message));
+            deprecateByVersion.AssertNotEmpty(nameof(deprecateByVersion));
+
+            this.message = message;
+            DeprecateByVersion = deprecateByVersion;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakingChangeBaseAttribute" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the breaking change.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        /// <param name="changeInEfectByDate">The data when the change will be required.</param>
+        public BreakingChangeBaseAttribute(string message, string deprecateByVersion, string changeInEfectByDate)
+        {
+            message.AssertNotEmpty(nameof(message));
+            deprecateByVersion.AssertNotEmpty(nameof(deprecateByVersion));
+            changeInEfectByDate.AssertNotEmpty(nameof(changeInEfectByDate));
+
+            this.message = message;
+            DeprecateByVersion = deprecateByVersion;
+            ChangeInEfectByDate = DateTime.Parse(changeInEfectByDate, CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Gets or sets the description for hte change.
+        /// </summary>
+        public string ChangeDescription { get; set; } = null;
+
+        /// <summary>
+        /// Gets the date the change will be required.
+        /// </summary>
+        public DateTime? ChangeInEfectByDate { get; } = null;
+
+        /// <summary>
+        /// Gets the version when this change will be depcreated.
+        /// </summary>
+        public string DeprecateByVersion { get; } = null;
+
+        /// <summary>
+        /// Gets or sets the new way the command should be invoked.
+        /// </summary>
+        public string NewWay { get; set; }
+
+        /// <summary>
+        /// Gets or sets the old way the command was invoked.
+        /// </summary>
+        public string OldWay { get; set; }
+
+        /// <summary>
+        /// Checks if the breaking change applies to how or where the command was invoked.
+        /// </summary>
+        /// <param name="invocationInfo">The description of how and where this command was invoked.</param>
+        /// <returns>
+        /// <c>true</c> if the breaking change applies to how or where the command was invoked; otherwise <c>false</c>.
+        /// </returns>
+        public virtual bool IsApplicableToInvocation(InvocationInfo invocation)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the specified message for the attribute.
+        /// </summary>
+        /// <returns>The specified message for the attribute.</returns>
+        protected virtual string GetAttributeSpecificMessage()
+        {
+            return message;
+        }
+
+        /// <summary>
+        /// Gets the name of the command from the type.
+        /// </summary>
+        /// <param name="type">The type for the command being invoked.</param>
+        /// <returns>The name of the command from the type.</returns>
+        public static string GetNameFromCmdletType(Type type)
+        {
+            string cmdletName = null;
+            CmdletAttribute cmdletAttrib = (CmdletAttribute)type.GetCustomAttributes(typeof(CmdletAttribute), false).FirstOrDefault();
+
+            if (cmdletAttrib != null)
+            {
+                cmdletName = cmdletAttrib.VerbName + "-" + cmdletAttrib.NounName;
+            }
+
+            return cmdletName;
+        }
+
+        /// <summary>
+        /// Writes the attribute information to the output.
+        /// </summary>
+        /// <param name="type">The type for the command being invoked.</param>
+        /// <param name="withCmdletName">A flag indicating whether or not to write the command name.</param>
+        /// <param name="writeOutput">The action used to write the output.</param>
+        public void PrintCustomAttributeInfo(Type type, bool withCmdletName, Action<string> writeOutput)
+        {
+            if (!withCmdletName)
+            {
+                writeOutput(
+                    string.Format(
+                        CultureInfo.CurrentCulture, 
+                        Resources.BreakingChangesAttributesDeclarationMessage, 
+                        GetAttributeSpecificMessage()));
+            }
+            else
+            {
+                writeOutput(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesDeclarationMessageWithCmdletName, 
+                        GetNameFromCmdletType(type), 
+                        GetAttributeSpecificMessage()));
+            }
+
+            if (!string.IsNullOrWhiteSpace(ChangeDescription))
+            {
+                writeOutput(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesChangeDescriptionMessage, 
+                        ChangeDescription));
+            }
+
+            if (ChangeInEfectByDate.HasValue)
+            {
+                writeOutput(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesInEffectByDateMessage, 
+                        ChangeInEfectByDate.Value));
+            }
+
+            if (!string.IsNullOrEmpty(DeprecateByVersion))
+            {
+                writeOutput(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesInEffectByVersion, 
+                        DeprecateByVersion));
+            }
+
+            if (OldWay != null && NewWay != null)
+            {
+                writeOutput(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesUsageChangeMessageConsole, 
+                        OldWay, 
+                        NewWay));
+            }
+        }
+    }
+}

--- a/src/PowerShell/Commands/ConnectPartnerCenter.cs
+++ b/src/PowerShell/Commands/ConnectPartnerCenter.cs
@@ -63,6 +63,12 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
         public PSCredential Credential { get; set; }
 
         /// <summary>
+        /// Gets or sets a flag indicating whether or not multi-factor authentication is enforced.
+        /// </summary>
+        [Parameter(HelpMessage = "A flag indicating whether or not multi-factor authentication is enforced. The is only configurable while the Partner Center API is not requiring multi-factor authentication.", Mandatory = false)]
+        public SwitchParameter EnforceMFA { get; set; }
+
+        /// <summary>
         /// Gets or sets the environment used for authentication.
         /// </summary>
         [Parameter(HelpMessage = "The environment use for authentication.", Mandatory = false)]
@@ -105,6 +111,8 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
             OrganizationProfile profile;
 
             WriteDebug(string.Format(CultureInfo.CurrentCulture, Resources.ConnectPartnerCenterBeginProcess, ParameterSetName));
+
+            PartnerService.Instance.EnforceMfa = (EnforceMFA.IsPresent && EnforceMFA.ToBool()) ? true : false;
 
             if (ParameterSetName.Equals(AccessTokenParameterSet, StringComparison.InvariantCultureIgnoreCase))
             {

--- a/src/PowerShell/Commands/DisconnectPartnerCenter.cs
+++ b/src/PowerShell/Commands/DisconnectPartnerCenter.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
             if (ShouldProcess(Resources.DisconnectWhatIf))
             {
                 PartnerSession.Instance.Context = null;
+                PartnerService.Instance.EnforceMfa = false;
             }
         }
     }

--- a/src/PowerShell/Commands/PartnerPSCmdlet.cs
+++ b/src/PowerShell/Commands/PartnerPSCmdlet.cs
@@ -6,8 +6,12 @@
 
 namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
 {
+    using System;
+    using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
     using System.Management.Automation;
+    using System.Reflection;
     using Authentication;
     using Exceptions;
     using Properties;
@@ -17,6 +21,11 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
     /// </summary>
     public abstract class PartnerPSCmdlet : PSCmdlet
     {
+        /// <summary>
+        /// The link that provide addtional information regarding the breaking change.
+        /// </summary>
+        private const string BREAKING_CHANGE_ATTRIBUTE_INFORMATION_LINK = "https://aka.ms/partnercenterps-changewarnings";
+
         /// <summary>
         /// Gets the available Partner Center operations.
         /// </summary>
@@ -38,6 +47,8 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
             }
 
             Partner = PartnerSession.Instance.ClientFactory.CreatePartnerOperations(d => WriteDebug(d));
+
+            ProcessBreakingChangeAttributesAtRuntime(GetType(), MyInvocation, WriteWarning);
         }
 
         /// <summary>
@@ -79,6 +90,88 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
         /// </summary>
         public virtual void ExecuteCmdlet()
         {
+        }
+
+        /// <summary>
+        /// Gets all of the breaking change attributes in the specified type.
+        /// </summary>
+        /// <param name="type">The type for the command being invoked.</param>
+        /// <param name="invocationInfo">The description of how and where this command was invoked.</param>
+        private static IEnumerable<BreakingChangeBaseAttribute> GetAllBreakingChangeAttributesInType(Type type, InvocationInfo invocationInfo)
+        {
+            {
+                List<BreakingChangeBaseAttribute> attributeList = new List<BreakingChangeBaseAttribute>();
+
+                attributeList.AddRange(type.GetCustomAttributes(typeof(BreakingChangeBaseAttribute), false).Cast<BreakingChangeBaseAttribute>());
+
+                foreach (MethodInfo m in type.GetRuntimeMethods())
+                {
+                    attributeList.AddRange((m.GetCustomAttributes(typeof(BreakingChangeBaseAttribute), false).Cast<BreakingChangeBaseAttribute>()));
+                }
+
+                foreach (FieldInfo f in type.GetRuntimeFields())
+                {
+                    attributeList.AddRange(f.GetCustomAttributes(typeof(BreakingChangeBaseAttribute), false).Cast<BreakingChangeBaseAttribute>());
+                }
+
+                foreach (PropertyInfo p in type.GetRuntimeProperties())
+                {
+                    attributeList.AddRange(p.GetCustomAttributes(typeof(BreakingChangeBaseAttribute), false).Cast<BreakingChangeBaseAttribute>());
+                }
+
+                return invocationInfo == null ? attributeList : attributeList.Where(e => e.IsApplicableToInvocation(invocationInfo));
+            }
+        }
+
+        /// <summary>
+        /// Processes the break changes defined for the cmdlet.
+        /// </summary>
+        /// <param name="type">The type for the command being invoked.</param>
+        /// <param name="invocationInfo">The description of how and where this command was invoked.</param>
+        /// <param name="writeOutput">The action used to write the output.</param>
+        private void ProcessBreakingChangeAttributesAtRuntime(Type type, InvocationInfo invocationInfo, Action<string> writeOutput)
+        {
+            List<BreakingChangeBaseAttribute> attributes =
+                new List<BreakingChangeBaseAttribute>(GetAllBreakingChangeAttributesInType(type, invocationInfo));
+
+            if (attributes != null && attributes.Count > 0)
+            {
+                writeOutput(
+                    string.Format(
+                        CultureInfo.CurrentCulture, 
+                        Resources.BreakingChangesAttributesHeaderMessage, 
+                        GetNameFromCmdletType(type)));
+
+                foreach (BreakingChangeBaseAttribute attribute in attributes)
+                {
+                    attribute.PrintCustomAttributeInfo(type, false, writeOutput);
+                }
+
+                writeOutput(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesFooterMessage, 
+                        BREAKING_CHANGE_ATTRIBUTE_INFORMATION_LINK));
+            }
+        }
+
+
+        /// <summary>
+        /// Gets the name of the command from the type.
+        /// </summary>
+        /// <param name="type">The type for the command being invoked.</param>
+        /// <returns>The name of the command from the type.</returns>
+        private static string GetNameFromCmdletType(Type type)
+        {
+            string cmdletName = null;
+            CmdletAttribute cmdletAttrib = (CmdletAttribute)type.GetCustomAttributes(typeof(CmdletAttribute), false).FirstOrDefault();
+
+            if (cmdletAttrib != null)
+            {
+                cmdletName = cmdletAttrib.VerbName + "-" + cmdletAttrib.NounName;
+            }
+
+            return cmdletName;
         }
     }
 }

--- a/src/PowerShell/PowerShell.csproj
+++ b/src/PowerShell/PowerShell.csproj
@@ -21,6 +21,9 @@
     <!-- This None is here so the conditionally included files show up in the Solution Explorer -->
     <None Include="**\*.cs;**\*.xml;**\*.axml" Exclude="obj\**\*.*;bin\**\*.*" />
     <Compile Remove="Platforms\**\*.*" />
+    <Compile Remove="BreakingChangeAttribute.cs" />
+    <Compile Remove="BreakingChangeBaseAttribute.cs" />
+    <Compile Remove="Common\BreakingChangeAttributeHelper.cs" />
     <ProjectReference Include="..\PartnerCenter\PartnerCenter.csproj" />
   </ItemGroup>
 

--- a/src/PowerShell/Properties/Resources.Designer.cs
+++ b/src/PowerShell/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.Store.PartnerCenter.PowerShell.Properties
-{
-
-
+namespace Microsoft.Store.PartnerCenter.PowerShell.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -174,6 +174,83 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Properties
         internal static string AuthenticationTypeNotSupportedException {
             get {
                 return ResourceManager.GetString("AuthenticationTypeNotSupportedException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change description : {0}.
+        /// </summary>
+        internal static string BreakingChangesAttributesChangeDescriptionMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesChangeDescriptionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to - {0}
+        ///.
+        /// </summary>
+        internal static string BreakingChangesAttributesDeclarationMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesDeclarationMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to - Cmdlet : &apos;{0}&apos;
+        /// - {1}.
+        /// </summary>
+        internal static string BreakingChangesAttributesDeclarationMessageWithCmdletName {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesDeclarationMessageWithCmdletName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NOTE : Go to {0} for steps to suppress this breaking change warning, and other information on breaking changes with the Partner Center PowerShell module..
+        /// </summary>
+        internal static string BreakingChangesAttributesFooterMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesFooterMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Breaking changes in the cmdlet &apos;{0}&apos; :.
+        /// </summary>
+        internal static string BreakingChangesAttributesHeaderMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesHeaderMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Note : This change will take effect on &apos;{0}&apos;.
+        /// </summary>
+        internal static string BreakingChangesAttributesInEffectByDateMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesInEffectByDateMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Note: The change is expected to take effect from the version &apos;{0}&apos;
+        ///.
+        /// </summary>
+        internal static string BreakingChangesAttributesInEffectByVersion {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesInEffectByVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cmdlet invocation changes :
+        ///	Old Way : {0}
+        ///	New Way : {1}.
+        /// </summary>
+        internal static string BreakingChangesAttributesUsageChangeMessageConsole {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesUsageChangeMessageConsole", resourceCulture);
             }
         }
         

--- a/src/PowerShell/Properties/Resources.resx
+++ b/src/PowerShell/Properties/Resources.resx
@@ -156,6 +156,35 @@
   <data name="AuthenticationTypeNotSupportedException" xml:space="preserve">
     <value>You have authenticated using {0} authentication. This type of authentication is not supported by this command, only {1} authentication is supported. Please establish a new connection using an alternative means of authentication.</value>
   </data>
+  <data name="BreakingChangesAttributesChangeDescriptionMessage" xml:space="preserve">
+    <value>Change description : {0}</value>
+  </data>
+  <data name="BreakingChangesAttributesDeclarationMessage" xml:space="preserve">
+    <value>- {0}
+</value>
+  </data>
+  <data name="BreakingChangesAttributesDeclarationMessageWithCmdletName" xml:space="preserve">
+    <value>- Cmdlet : '{0}'
+ - {1}</value>
+  </data>
+  <data name="BreakingChangesAttributesFooterMessage" xml:space="preserve">
+    <value>NOTE : Go to {0} for steps to suppress this breaking change warning, and other information on breaking changes with the Partner Center PowerShell module.</value>
+  </data>
+  <data name="BreakingChangesAttributesHeaderMessage" xml:space="preserve">
+    <value>Breaking changes in the cmdlet '{0}' :</value>
+  </data>
+  <data name="BreakingChangesAttributesInEffectByDateMessage" xml:space="preserve">
+    <value>Note : This change will take effect on '{0}'</value>
+  </data>
+  <data name="BreakingChangesAttributesInEffectByVersion" xml:space="preserve">
+    <value>Note: The change is expected to take effect from the version '{0}'
+</value>
+  </data>
+  <data name="BreakingChangesAttributesUsageChangeMessageConsole" xml:space="preserve">
+    <value>Cmdlet invocation changes :
+	Old Way : {0}
+	New Way : {1}</value>
+  </data>
   <data name="CheckoutPartnerCustomerCartWhatIf" xml:space="preserve">
     <value>Checks out the cart with the identifier of {0}.</value>
   </data>


### PR DESCRIPTION
# Description

Through this pull request the following changes are being made 

1. Add the ability to control whether or not MFA is required when using app + user authentication. This feature will only be available while the Partner Center API is not enforcing this requirement. 
2. Add a new feature to notify users of upcoming breaking changes. This approach follows what the Azure PowerShell module has implemented. 
3. Modified the version of Newtonsoft.Json used by the .NET 4.6.1 version of the Partner Center library. This address a newly discovered compatibility issue with the Az module running on PowerShell version 5.

## Related issue

N/A