### PR TITLE
Invoice and subscription feature update

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,13 @@
 
 # Change Log
 
+## Upcoming Release
+
+* Invoices
+  * Addressed issue [#117](https://github.com/Microsoft/Partner-Center-PowerShell/issues/117), where the cannot access stream error was being thrown
+* Subscriptions
+  * Added breaking change warning for the removal the *AutoRenew* flag from the [Set-PartnerCustomerSubscription](https://docs.microsoft.com/powershell/module/partnercenter/set-partnercustomersubscription) command
+
 ## 1.5.1904.2
 
 * Authentication

--- a/docs/upcoming-breaking-changes.md
+++ b/docs/upcoming-breaking-changes.md
@@ -1,0 +1,29 @@
+<!--
+    Please leave this section at the top of the breaking change documentation.
+
+    New breaking changes should go under the section titled "Upcoming Breaking Changes", and should adhere to the following format:
+
+    # Upcoming Breaking Changes
+
+    ## Release X.0.0 - January 2017
+
+    The following cmdlets were affected by this release:
+
+    **Cmdlet 1**
+    - Description of what has changed
+
+    ```powershell
+    # Old
+    # Sample of how the cmdlet was previously called
+
+    # New
+    # Sample of how the cmdlet should now be called
+    ```
+-->
+
+# Upcoming Breaking Changes
+
+## Release 1.5.1905.1 - May 2019
+
+* Subscriptions
+  * The *AutoRenew* flag will be removed from the [Set-PartnerCustomerSubscription](https://docs.microsoft.com/powershell/module/partnercenter/set-partnercustomersubscription) command

--- a/src/PowerShell/Attributes/BreakingChangeBaseAttribute.cs
+++ b/src/PowerShell/Attributes/BreakingChangeBaseAttribute.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Store.PartnerCenter.PowerShell
         /// </summary>
         /// <param name="message">The message that describes the breaking change.</param>
         /// <param name="deprecateByVersion">The version where the change will be required.</param>
-        /// <param name="changeInEfectByDate">The data when the change will be required.</param>
+        /// <param name="changeInEfectByDate">The date when the change will be required.</param>
         protected BreakingChangeBaseAttribute(string message, string deprecateByVersion, string changeInEfectByDate)
         {
             message.AssertNotEmpty(nameof(message));
@@ -66,7 +66,7 @@ namespace Microsoft.Store.PartnerCenter.PowerShell
         }
 
         /// <summary>
-        /// Gets or sets the description for hte change.
+        /// Gets or sets the description for the change.
         /// </summary>
         public string ChangeDescription { get; set; } = null;
 

--- a/src/PowerShell/Commands/GetPartnerInvoiceStatement.cs
+++ b/src/PowerShell/Commands/GetPartnerInvoiceStatement.cs
@@ -54,37 +54,29 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
             }
 
             DirectoryInfo dirInfo = Directory.CreateDirectory(OutputPath);
-            string filePath = "";
+            string filePath;
 
             if (dirInfo.FullName.EndsWith(Path.DirectorySeparatorChar.ToString(CultureInfo.CurrentCulture), System.StringComparison.CurrentCulture))
             {
-                filePath = dirInfo.FullName + InvoiceId + ".pdf";
+                filePath = $"{dirInfo.FullName}{InvoiceId}.pdf";
             }
             else
             {
-                filePath = dirInfo.FullName + Path.DirectorySeparatorChar.ToString(CultureInfo.CurrentCulture) + InvoiceId + ".pdf";
+                filePath = $"{dirInfo.FullName}{Path.DirectorySeparatorChar.ToString(CultureInfo.CurrentCulture)}{InvoiceId}.pdf";
             }
 
             if (File.Exists(filePath) && !Overwrite.IsPresent)
             {
-                throw new PSInvalidOperationException("The path already exists: " + filePath + ". Specify the -Overwrite switch to overwrite the file");
+                throw new PSInvalidOperationException($"The path already exists: {filePath}. Specify the -Overwrite switch to overwrite the file");
             }
 
-            GetStatement(InvoiceId, filePath);
-        }
-
-        /// <summary>
-        ///  Gets the specified invoice statement for the specified invoiceId and outputs the PDF file to outputPath
-        /// </summary>
-        private void GetStatement(string invoiceId, string filePath)
-        {
-            FileStream file;
-
-            using (Stream stream = Partner.Invoices.ById(invoiceId).Documents.Statement.GetAsync().GetAwaiter().GetResult())
+            using (Stream stream = Partner.Invoices.ById(InvoiceId).Documents.Statement.GetAsync().GetAwaiter().GetResult())
             {
-                file = File.Create(filePath);
+                FileStream file = File.Create(filePath);
                 stream.Seek(0, SeekOrigin.Begin);
                 stream.CopyTo(file);
+
+                file.Close();
             }
         }
     }

--- a/src/PowerShell/Commands/SetPartnerCustomerSubscription.cs
+++ b/src/PowerShell/Commands/SetPartnerCustomerSubscription.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Commands
         /// <summary>
         /// Gets or sets a flag indicating whether or not the subscription will auto renew.
         /// </summary>
+        [BreakingChange("The auto renew flag cannot be modified. So, this parameter will be removed.", "1.5.1905.1", "5/1/2019")]
         [Parameter(HelpMessage = "A flag indicating whether or not the subscription will auto renew.", ParameterSetName = "Customer", Mandatory = false)]
         [Parameter(HelpMessage = "A flag indicating whether or not the subscription will auto renew.", ParameterSetName = "CustomerObject", Mandatory = false)]
         public bool? AutoRenew { get; set; }


### PR DESCRIPTION
# Description

Through this pull request the following changes are being made

* Invoices
  * Addressed issue [#117](https://github.com/Microsoft/Partner-Center-PowerShell/issues/117), where the cannot access stream error was being thrown
* Subscriptions
  * Added breaking change warning for the removal the *AutoRenew* flag from the [Set-PartnerCustomerSubscription](https://docs.microsoft.com/powershell/module/partnercenter/set-partnercustomersubscription) command

## Related issue

#117