### PR TITLE
HTTP timeout

### DIFF
--- a/src/PowerShell/Factories/ClientFactory.cs
+++ b/src/PowerShell/Factories/ClientFactory.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Store.PartnerCenter.PowerShell.Factories
         /// <summary>
         /// The client used to perform HTTP operations.
         /// </summary>
-        private static readonly HttpClient HttpClient = new HttpClient(new RetryDelegatingHandler
+        private static readonly HttpClient HttpClient = new HttpClient(new RetryDelegatingHandler { InnerHandler = new HttpClientHandler() })
         {
-            InnerHandler = new HttpClientHandler()
-        });
+            Timeout = TimeSpan.FromMinutes(3)
+        };
 
         /// <summary>
         /// Creates a new instance of the Microsoft Graph service client.

--- a/src/PowerShell/PowerShell.csproj
+++ b/src/PowerShell/PowerShell.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.6.0-preview" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.6.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.6.0" />
     <PackageReference Include="PartnerCenter.DotNet" Version="1.15.6" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="All" />
   </ItemGroup>

--- a/test/PowerShell.UnitTests/PowerShell.UnitTests.csproj
+++ b/test/PowerShell.UnitTests/PowerShell.UnitTests.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

Through this pull request the following changes are being made 

- HTTP timeout value is being set to three minutes for the HTTP client interacting with the Partner Center API 
- Updating the test dependency references 

## Related issue

#312 